### PR TITLE
fix: Fixes spacing for first comment

### DIFF
--- a/app/Http/Controllers/ItemController.php
+++ b/app/Http/Controllers/ItemController.php
@@ -54,6 +54,16 @@ class ItemController extends Controller
     }
 
     /**
+     * Show the form for creating a new resource.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     */
+    public function create(Request $request)
+    {
+        //
+    }
+
+    /**
      * Store a newly created resource in storage.
      *
      * @param  \Illuminate\Http\Request  $request
@@ -61,35 +71,7 @@ class ItemController extends Controller
      */
     public function store(Request $request)
     {
-        $request->validate([
-            'type' => 'required',
-            'title' => 'required',
-            'hidden' => 'required',
-            'location_id' => 'required',
-            'category_id' => 'required',
-            'description' => 'required',
-        ]);
-
-        $item_type = $request->type;
-        // TODO: checar location e category
-
-        $item = new Item([
-            'user_id' => Auth::user()->id,
-            'location_id' => $request->location_id,
-            'category_id' => $request->category_id,
-            'status' => Item::STATUS_ACTIVE,
-            'type' => $item_type,
-            'title' => $request->title,
-            'description' => $request->description,
-            'hidden' => SELF::isItemVisible($item_type, $request -> hidden)
-        ]);
-
-        $item->save();
-
-        return response(
-            ['message' => SELF::RESPONSE_MESSAGES[$item_type]],
-            Response::HTTP_CREATED
-        );
+        //
     }
 
     /**
@@ -150,7 +132,7 @@ class ItemController extends Controller
         $item->type = $request -> type;
         $item->title = $request->get('title');
         $item->description = $request->get('description');
-        $item->hidden = SELF::isItemVisible($request -> type, $request -> hidden);
+        $item->hidden = $request -> hidden == 'on' ? false : true;
         $item->updated_at = Carbon::now();
 
         $item->save();

--- a/resources/js/components/CommentListComponent.vue
+++ b/resources/js/components/CommentListComponent.vue
@@ -107,16 +107,16 @@ export default {
                 'text': this.userComment
             });
 
-            this.comments.push(comment.data);
-
-            this.userComment = '';
-
             if (!this.hasComment()) {
                 document.querySelector('#timeline .timeline__card').style.marginTop = '0';
 
             } else {
                 document.querySelector('#timeline .timeline__item:last-child').style.paddingBottom = '0';
             }
+
+            this.comments.push(comment.data);
+
+            this.userComment = '';
         },
 
         hasComment() {

--- a/resources/sass/components/timeline.scss
+++ b/resources/sass/components/timeline.scss
@@ -102,6 +102,7 @@ ul[class="timeline__list"] {
 
 .timeline__reactions {
     padding-top: $tl-base-padding / 2;
+    padding-right: 24px;
 }
 
 /**

--- a/routes/web.php
+++ b/routes/web.php
@@ -15,7 +15,7 @@ use Illuminate\Support\Facades\App;
 */
 
 Route::resource('/items', 'ItemController')->except([
-    'create',
+    'create', 'store'
 ]);
 
 // Auth


### PR DESCRIPTION
closes #102 

Além de corrigir o espaçamento do primeiro comentário, esta PR remove a rota `items.store` que não estava mais sendo utilizada e corrige o alinhamento entre os botões de criar reação para item e para comentário.