### PR TITLE
feat(document): adds basic Document CRUD.

### DIFF
--- a/app/Document.php
+++ b/app/Document.php
@@ -6,6 +6,10 @@ use Illuminate\Database\Eloquent\Model;
 
 class Document extends Model
 {
+    protected $fillable = [
+        'name', 'path', 'mime_type', 'description', 'item_id'
+    ];
+
     public function item()
     {
         return $this->belongsTo('App\Item');

--- a/app/Http/Controllers/API/DocumentController.php
+++ b/app/Http/Controllers/API/DocumentController.php
@@ -1,0 +1,126 @@
+<?php
+
+namespace App\Http\Controllers\API;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\Request;
+use Illuminate\Http\Response;
+use Illuminate\Support\Facades\Storage;
+
+use App\Document;
+
+use App\Http\Resources\DocumentResource;
+
+class DocumentController extends Controller
+{
+    /**
+     * Display a listing of the resource.
+     *
+     * @return \Illuminate\Http\Response
+     */
+    public function index()
+    {
+        return DocumentResource::collection(Document::paginate());
+    }
+
+    /**
+     * Store a newly created resource in storage.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return \Illuminate\Http\Response
+     */
+    public function store(Request $request)
+    {
+        if ($file = $request->file('document')) {
+            $fileName = time() . '_' . $file->getClientOriginalName();
+            $fileExtension = $file->extension();
+            $file->storeAs('documents', $fileName);
+
+            $document = Document::create([
+                'name' => $fileName,
+                'path' => 'documents/' . $fileName,
+                'mime_type' => $fileExtension,
+                'description' => $request->description,
+                'item_id' => $request->item_id
+            ]);
+
+            return response(
+                new DocumentResource($document),
+                Response::HTTP_CREATED
+            );
+        }
+
+    }
+
+    /**
+     * Display the specified resource.
+     *
+     * @param  int  $id
+     * @return \Illuminate\Http\Response
+     */
+    public function show($id)
+    {
+        return response(
+            new DocumentResource(Document::find($id)),
+            Response::HTTP_OK
+        );
+    }
+
+    /**
+     * Update the specified resource in storage.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  int  $id
+     * @return \Illuminate\Http\Response
+     */
+    public function update(Request $request, $id)
+    {
+        $document = Document::find($id);
+        
+        if ($file = $request->file('document')) {
+            Storage::delete('documents/' . $document->name);
+
+            $fileName = time() . '_' . $file->getClientOriginalName();
+            $fileExtension = $file->extension();
+            $file->storeAs('documents', $fileName);
+        
+            $document->update([
+                'name' => $fileName,
+                'path' => 'documents/' . $fileName,
+                'mime_type' => $fileExtension,
+                'description' => $request->description,
+                'item_id' => $request->item_id
+            ]);
+        
+        } else {
+            $document->update([
+                'description' => $request->description,
+                'item_id' => $request->item_id
+            ]);
+        }
+
+        return response(
+            new DocumentResource($document),
+            Response::HTTP_OK
+        );
+    }
+
+    /**
+     * Remove the specified resource from storage.
+     *
+     * @param  int  $id
+     * @return \Illuminate\Http\Response
+     */
+    public function destroy($id)
+    {
+        $fileName = Document::find($id)->name;
+        Document::destroy($id);
+
+        Storage::delete('documents/' . $fileName);
+
+        return response(
+            null,
+            Response::HTTP_NO_CONTENT
+        );
+    }
+}

--- a/app/Http/Resources/DocumentResource.php
+++ b/app/Http/Resources/DocumentResource.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Http\Resources;
+
+use Illuminate\Http\Resources\Json\JsonResource;
+
+class DocumentResource extends JsonResource
+{
+    /**
+     * Transform the resource into an array.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return array
+     */
+    public function toArray($request)
+    {
+        return parent::toArray($request);
+    }
+}

--- a/config/filesystems.php
+++ b/config/filesystems.php
@@ -79,6 +79,7 @@ return [
 
     'links' => [
         public_path('storage') => storage_path('app/public'),
+        public_path('documents') => storage_path('app/documents')
     ],
 
 ];

--- a/routes/api.php
+++ b/routes/api.php
@@ -39,3 +39,5 @@ Route::apiResource('categories', 'API\CategoryController')->only([
 Route::apiResource('locations', 'API\LocationController')->only([
     'index'
 ]);
+
+Route::apiResource('documents', 'API\DocumentController');


### PR DESCRIPTION
colses #110 

Esta _issue_ cria uma estrutura básica para o CRUD de documentos.

Dado que são enviados arquivos, requisições devem obedecer o formato `multipart/form-data` (ou seja, utilizar o cabeçalho `'Content-Type': 'multipart/form-data'`). Para o método `PUT`, deverá ser utilizado um campo `_method=PUT`, utilizando o método `POST` para requisição, como [descrito na documentação](https://laravel.com/docs/8.x/blade#method-field).