### PR TITLE
melhorias de UX/UI

### DIFF
--- a/app/Http/Controllers/API/ItemController.php
+++ b/app/Http/Controllers/API/ItemController.php
@@ -10,6 +10,8 @@ use App\Item;
 use App\User;
 use App\Specification;
 
+use Carbon\Carbon;
+
 use App\Http\Resources\ItemResource;
 use App\Http\Resources\CommentResource;
 
@@ -149,6 +151,9 @@ class ItemController extends Controller
             'description' => $request -> text,
             'hidden' => false,
         ]);
+
+        $item = Item::find($parentId);
+        $item->touch();
 
         return response(
             new CommentResource($comment),

--- a/app/Http/Controllers/ItemController.php
+++ b/app/Http/Controllers/ItemController.php
@@ -5,9 +5,13 @@ namespace App\Http\Controllers;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
+
 use App\Item;
+use App\User;
 use App\Location;
 use App\Category;
+use App\Specification;
+
 use Carbon\Carbon;
 
 use App\Http\Resources\CommentResource;
@@ -83,6 +87,10 @@ class ItemController extends Controller
     public function show($id)
     {
         $item = Item::find($id);
+        $item['user'] = User::find($item->user_id)->name;
+        $item['location_id'] = Location::find($item->location_id)->name;
+        $item['category_id'] = Category::find($item->category_id)->name;
+        $item['specification_id'] = Specification::find($item->specification_id);
 
         return view('pages.item', [
             'user' => Auth::user(),
@@ -128,6 +136,7 @@ class ItemController extends Controller
         $item->user_id = Auth::user()->id;
         $item->location_id = $request->get('location_id');
         $item->category_id = $request->get('category_id');
+        $item->specification_id = $request->get('specification_id');
         $item->status = Item::STATUS_WAITING;
         $item->type = $request -> type;
         $item->title = $request->get('title');

--- a/app/Http/Resources/FeedbackResource.php
+++ b/app/Http/Resources/FeedbackResource.php
@@ -5,6 +5,9 @@ namespace App\Http\Resources;
 use Illuminate\Http\Resources\Json\JsonResource;
 
 use App\User;
+use App\Location;
+use App\Category;
+use App\Specification;
 
 class FeedbackResource extends JsonResource
 {
@@ -19,10 +22,9 @@ class FeedbackResource extends JsonResource
         return [
             'id' => $this->id,
             'user_id' => $this->user_id,
-            'user' => User::find($this->user_id),
-            'location_id' => $this->location_id,
-            'category_id' => $this->category_id,
-            'status' => $this->status,
+            'user' => User::find($this->user_id)->name,
+            'location_id' => Location::find($this->location_id)->name,
+            'category_id' => Category::find($this->category_id)->name,
             'title' => $this->title,
             'description' => $this->description,
             'hidden' =>$this->hidden,

--- a/app/Http/Resources/ServiceResource.php
+++ b/app/Http/Resources/ServiceResource.php
@@ -4,8 +4,10 @@ namespace App\Http\Resources;
 
 use Illuminate\Http\Resources\Json\JsonResource;
 
-use App\Specification;
 use App\User;
+use App\Location;
+use App\Category;
+use App\Specification;
 
 class ServiceResource extends JsonResource
 {
@@ -21,14 +23,15 @@ class ServiceResource extends JsonResource
             'id' => $this->id,
             'user_id' => $this->user_id,
             'user' => User::find($this->user_id)->username,
-            'location_id' => $this->location_id,
-            'category_id' => $this->category_id,
-            'specification_id' => $this->specification_id,
+            'location_id' => Location::find($this->location_id)->name,
+            'category_id' => Category::find($this->category_id)->name,
+            'specification_id' => Specification::find($this->specification_id)->title,
             'status' => $this->status,
             'title' => $this->title,
             'description' => $this->description,
             'created_at' => $this->created_at,
-            'updated_at' => $this->updated_at
+            'updated_at' => $this->updated_at,
+            'github_issue_link' => $this->github_issue_link,
         ];
     }
 }

--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -51,7 +51,7 @@ Vue.component('admin-page',require('./components/admin/AdminPage.vue').default);
 Vue.filter('formatDate', function(value) {
     moment.locale();
     if (value) {
-        return moment(String(value)).format('MM/DD/YYYY')
+        return moment(String(value)).format('DD/MM/YYYY')
     }
 }); 
 Vue.filter('prettyDate', function(value) {

--- a/resources/js/components/admin/Services.vue
+++ b/resources/js/components/admin/Services.vue
@@ -3,7 +3,7 @@
                d-flex justify-content-around align-items-center">
         <a :href="service.github_issue_link">
             <img class="github-icon"
-                 :class="{'inactive':service.github_issue_link !== ''}"
+                 :class="{'inactive':!service.github_issue_link}"
                  :src="'/img/GitHub-Mark-64px.png'"
                  alt="link para a isssue no github" title="link para a isssue no github"
             >
@@ -11,10 +11,11 @@
         <div class="'col-sm-11 col-md-6 text-left">
             <p><strong>{{service.title}} </strong><small>- atualizadada {{service.updated_at | prettyDate}}</small> </p>
             <p>{{service.description.substring(0,150)+"..." }}</p>
+            <p><small>Categoria: {{service.specification_id}}, Localização: {{service.location_id}}</small></p>
         </div>
         <div>
             <p><strong>Usuario</strong></p>
-            <p>{{service.user.username}}</p>
+            <p>{{service.user}}</p>
         </div>
         <div>
             <p><strong>Categoria</strong></p>
@@ -32,7 +33,7 @@
            class="row col-sm-12 col-md-1 
                   justify-content-center ">
             <span class="material-icons">insert_comment</span>
-            <p>Acompanhar</p>
+            <p><small>Acompanhar</small></p>
         </a>
     </div>
 </template>

--- a/resources/js/components/feedbacks/Feedback.vue
+++ b/resources/js/components/feedbacks/Feedback.vue
@@ -1,12 +1,11 @@
 <template>
 <div class="card m-1" >
 <a class="card-link" :href="'/feedback/'+feedback.id">
-  <div class="card-body">
+  <div class="card-body text-left">
     <h5 class="card-title">{{feedback.title}}</h5>
-    <h6 class="card-subtitle mb-2 text-muted">{{feedback.user.name}} - {{feedback.created_at | formatDate}}</h6>
+    <p class="card-subtitle mb-2 text-muted"><small>{{feedback.user}} - {{feedback.created_at | formatDate}}</small></p>
     <p class="card-text">{{feedback.description}}</p>
-    <!-- <a href="" class="card-link">Localização {{feedback.location_id}}</a>
-    <a href="" class="card-link">Categoria {{feedback.category_id}}</a> -->
+    <p class="card-link"><small>{{feedback.location_id}}</small></p>
   </div>
 </a>
 </div>

--- a/resources/js/components/index/Feedbacks.vue
+++ b/resources/js/components/index/Feedbacks.vue
@@ -8,7 +8,8 @@
                 <div clas="p-5">
                     <h3 class="card-title">{{feedback.title}}</h3>
                     <p class="card-text">{{feedback.description}}</p>
-                    <small>{{feedback.user.name}} - {{ feedback.created_at | formatDate }} </small>
+                    <p><small>{{feedback.user}} - {{ feedback.created_at | formatDate }} </small></p>
+                    <p><small>{{feedback.location_id}} </small></p>
                 </div>
             </div>
         </div>
@@ -37,7 +38,7 @@ export default {
         async fetchFeedbacks() {
             let { data } = await axios.get('/api/feedbacks?limit=5');
 
-            this.feedbacks = data.data;
+            this.feedbacks = data.data.filter(fb => fb.category_id == "Crítica");
         },
     },
     created() {

--- a/resources/js/components/items/ItemPage.vue
+++ b/resources/js/components/items/ItemPage.vue
@@ -1,7 +1,11 @@
 <template>
   <div class="col-8">
+      <h6>{{item.user}}</h6>
       <h4>{{item.title}}</h4>
       <p v-if="item.github_issue_link"><a :href="item.github_issue_link" target="_blank"><small>Acompanhe essa solicitação no GitHub</small></a></p>
+      <p><small>Categoria: {{item.category_id}}</small>
+         <small v-if="item.specification_id">:{{item.specification_id.title}}</small>, 
+         <small>Localização: {{item.location_id}}</small></p>
       <p>{{item.description}}</p>
       <p class="text-right"> <small> última atualização {{item.updated_at | prettyDate}}</small></p>
     <hr>


### PR DESCRIPTION
Algumas melhorias de UX/UI à serem feitas
- [x]  Ajustar o formato da data exibidas que estão Mês/Dia/Ano e devem ser Dia/Mês/Ano
- [x]  Na página Home, filtrar e exibir os feedbacks apenas pelos que são críticas
- [x]  Na página da listagem e realização de feedbacks exibir a localização pelo nome, de onde vem aquele feedback
- [x]  Na página individual de feedbacks e serviços solicitados (item):
- - [x]  Exibir o nome do solicitante
- - [x]  Exibir abaixo do titulo a categoria e localização do item
- - [x]  atualizar o `update_at` toda vez que for feito um comentário
- [x]  Na pagina de serviços o campo categoria deve ser o nome por extenso e não o id
- [x]  Na pagina Admin deve:
- - [x]  Corrigir o ícone do github quando há um link da issue cadastrado, que não está diferenciando
- - [x]  Corrigir o campo categoria para aparecer o nome da categoria e não o id
- - [x]  Deve-se exibir também a especificação e localização do serviço solicitado
