### PR TITLE
feat(add delivery date on services)

### DIFF
--- a/app/Http/Controllers/API/ServiceController.php
+++ b/app/Http/Controllers/API/ServiceController.php
@@ -60,7 +60,7 @@ class ServiceController extends Controller
             'specification_id' => 'required',
             'title' => 'required',
             'description' => 'required',
-            'delivery_date' => 'nullable'
+            'delivery_date' => 'required'
         ]);
 
         $data['hidden'] = false;
@@ -104,7 +104,7 @@ class ServiceController extends Controller
             'title' => 'required',
             'specification_id' => 'required',
             'description' => 'required',
-            'delivery_date' => 'nullable'
+            'delivery_date' => 'required'
         ]);
 
         $item = Item::find($id);

--- a/app/Http/Controllers/API/ServiceController.php
+++ b/app/Http/Controllers/API/ServiceController.php
@@ -37,11 +37,11 @@ class ServiceController extends Controller
 
         if ($user -> isAdmin()) {
             $items = SELF::getServicesForAdminUser();
-        
+
         } else {
             $items = SELF::getServicesForNormalUser($user -> id);
         }
-        
+
         return ServiceResource::collection($items -> paginate(10000));
     }
 
@@ -59,9 +59,10 @@ class ServiceController extends Controller
             'category_id' => 'required',
             'specification_id' => 'required',
             'title' => 'required',
-            'description' => 'required'
+            'description' => 'required',
+            'delivery_date' => 'nullable'
         ]);
-        
+
         $data['hidden'] = false;
         $data['type'] = Item::TYPE_SERVICE;
         $data['status'] = Item::STATUS_WAITING;
@@ -102,7 +103,8 @@ class ServiceController extends Controller
             'category_id' => 'required',
             'title' => 'required',
             'specification_id' => 'required',
-            'description' => 'required'
+            'description' => 'required',
+            'delivery_date' => 'nullable'
         ]);
 
         $item = Item::find($id);
@@ -114,7 +116,8 @@ class ServiceController extends Controller
         $item->title = $request->get('title');
         $item->description = $request->get('description');
         $item->github_issue_link = $request->get('github_issue_link');
-        
+        $item->delivery_date = $request->get('delivery_date');
+
         $item->save();
         $item->touch();
     }

--- a/app/Http/Resources/ServiceResource.php
+++ b/app/Http/Resources/ServiceResource.php
@@ -32,6 +32,7 @@ class ServiceResource extends JsonResource
             'created_at' => $this->created_at,
             'updated_at' => $this->updated_at,
             'github_issue_link' => $this->github_issue_link,
+            'delivery_date' => $this->delivery_date,
         ];
     }
 }

--- a/app/Item.php
+++ b/app/Item.php
@@ -36,6 +36,7 @@ class Item extends Model
         'type',
         'title',
         'description',
+        'delivery_date',
         'github_issue_link',
         'hidden'
     ];
@@ -79,13 +80,13 @@ class Item extends Model
     {
         $reactionsAmount = Array();
         $reactions = $this->find($this->id)->reactions->groupBy('text');
-        
+
         $reactionNames = $reactions->keys();
 
         foreach($reactionNames as $reactionName) {
             $reactionsAmount[$reactionName] = $reactions[$reactionName]->count();
         }
-        
+
         return $reactionsAmount;
     }
 

--- a/database/migrations/2020_07_06_185039_create_items_table.php
+++ b/database/migrations/2020_07_06_185039_create_items_table.php
@@ -26,6 +26,7 @@ class CreateItemsTable extends Migration
             $table->integer('type')->default(1);
             $table->string('title', 200)->default('');
             $table->text('description')->nullable();
+            $table->date('delivery_date')->nullable();
             $table->boolean('hidden')->default(false);
             $table->text('github_issue_link')->nullable();
             $table->timestamps();

--- a/resources/js/components/admin/Services.vue
+++ b/resources/js/components/admin/Services.vue
@@ -5,7 +5,7 @@
             <div class="w-100">
                 <div class="col-sm-12 p-3 text-start w-100">
                     <p class="title mb-1"><strong>{{service.title}}</strong></p>
-                    <p>{{service.description.substring(0,150)}} <i v-if="service.description.length > 150">...</i></p>
+                    <p>{{service.description.substring(0,150)}}<i v-if="service.description.length > 150">...</i></p>
                     <p class="text-muted"><small>Solicitado por: {{service.user}}</small></p>
                 </div>
 
@@ -67,7 +67,7 @@
                 </div>
 
                 <div class="col-12 text-end text-muted p-3 d-flex justify-content-between align-items-center">
-                    <a :href="service.github_issue_link">
+                    <a :href="service.github_issue_link" target="_blank">
                         <img class="github-icon"
                             :class="{'inactive':!service.github_issue_link}"
                             :src="'/img/GitHub-Mark-64px.png'"

--- a/resources/js/components/admin/Services.vue
+++ b/resources/js/components/admin/Services.vue
@@ -1,61 +1,85 @@
 <template>
      <div class="p-1 col-sm-12 col-md-4">
+        <div class="my-service text-center" :class="service.status|status_class">
 
-        <div class="my-service text-center " :class="service.status|status_class">
+            <div class="w-100">
+                <div class="col-sm-12 p-3 text-start w-100">
+                    <p class="title mb-1"><strong>{{service.title}}</strong></p>
+                    <p>{{service.description.substring(0,150)}} <i v-if="service.description.length > 150">...</i></p>
+                    <p class="text-muted"><small>Solicitado por: {{service.user}}</small></p>
+                </div>
 
-            <div class="col-sm-12 text-start">
-                <p><strong>{{service.title}}</strong></p>
-                <p>{{service.description.substring(0,150)+"..." }}</p>
-                <p class="text-muted"><small>Solicitado por: {{service.user}}</small></p>
+                <div class="p-1 w-100">
+                    <div class="col-12 mb-2 d-flex justify-center align-items-stretch flex-wrap">
+                        <div class="d-flex flex-column justify-content-center item_box">
+                            <div class="p-2">
+                                <b>Id</b>
+                            </div>
+                            <div class="p-2">
+                                {{service.id}}
+                            </div>
+                        </div>
+                        <div class="d-flex flex-column justify-content-center item_box">
+                            <div class="p-2">
+                                <b>Categoria</b>
+                            </div>
+                            <div class="p-2">
+                                {{service.specification_id}}
+                            </div>
+                        </div>
+                        <div class="d-flex flex-column justify-content-center item_box">
+                            <div class="p-2">
+                                <b>Data</b>
+                            </div>
+                            <div class="p-2">
+                                {{service.created_at | formatDate}}
+                            </div>
+                        </div>
+                        <div class="d-flex flex-column justify-content-center item_box" v-if="service.delivery_date">
+                            <div class="p-2">
+                                <b>Data de Entrega</b>
+                            </div>
+                            <div class="p-2">
+                                {{service.delivery_date | formatDate}}
+                            </div>
+                        </div>
+                    </div>
+                </div>
             </div>
 
-            <table class="col-12 mb-2">
-                <thead>
-                <tr>
-                    <th>Id</th>
-                    <th>Categoria</th>
-                    <th>Data</th>
-                </tr>
-                </thead>
-                <tbody>
-                <tr>
-                    <td>{{service.id}}</td>
-                    <td>{{service.specification_id}}</td>
-                    <td>{{service.created_at | formatDate}}</td>
-                </tr>
-                </tbody>
-            </table>
-
-            <div class="col-12 mt-2 row">
-                <div class="col-sm-6">
-                    <div class="row">
-                        <a :href="service.github_issue_link" class="col-12">
-                            <img class="github-icon"
-                                :class="{'inactive':!service.github_issue_link}"
-                                :src="'/img/GitHub-Mark-64px.png'"
-                                alt="link para a isssue no github" title="link para a isssue no github"
-                            >
+            <div class="w-100">
+                <div class="d-flex flex-row justify-content-center w-100 p-2">
+                    <div class="col-sm-5">
+                        <a :href="'/servico/'+service.id+'/edit'">
+                        <span class="material-icons col-12">grading</span>
+                        Editar</a>
+                    </div>
+                    <div class="col-sm-5">
+                        <a :href="'/servico/'+service.id">
+                            <span class="material-icons">insert_comment</span>
+                            <p>Acompanhar</p>
                         </a>
-                        <a :href="'/servico/'+service.id+'/edit'"
-                            class="p-2"
-                        >Editar</a>
-                    </div>   
+                    </div>
                 </div>
-                <div class="col-sm-6">
-                    <a :href="'/servico/'+service.id">
-                        <span class="material-icons">insert_comment</span>
-                        <p>Acompanhar</p>
+
+                <div class="col-sm-2">
+
+                </div>
+
+                <div class="col-12 text-end text-muted p-3 d-flex justify-content-between align-items-center">
+                    <a :href="service.github_issue_link">
+                        <img class="github-icon"
+                            :class="{'inactive':!service.github_issue_link}"
+                            :src="'/img/GitHub-Mark-64px.png'"
+                            alt="link para a isssue no github" title="link para a isssue no github"
+                        >
                     </a>
+
+                    <small><i class="bi bi-alarm"></i> última atualização {{service.updated_at | prettyDate}}</small>
                 </div>
             </div>
-
-            <div class="col-12 text-end text-muted "> 
-                <small><i class="bi bi-alarm"></i> última atualização {{service.updated_at | prettyDate}}</small>
-            </div>
-
         </div>
-
-   </div>
+    </div>
 </template>
 
 <script>
@@ -71,15 +95,16 @@ export default {
     background-color: #f0f0f0;
     border-left: 5px solid;
     border-radius: 8px;
-    padding: 30px;
+    padding: 0px, 30px;
     height: 100%;
 
     display: flex;
+    flex-direction: column;
     flex-wrap: wrap;
-    flex-direction: row;
-    align-items: center;
+    justify-content: space-between;
     align-content: center;
-    justify-content: space-around;
+    align-items: center;
+    word-wrap: break-word;
 }
 .my-service:hover{
     background-color: #ededed;
@@ -120,9 +145,17 @@ a, a:hover, a:visited, a:active{
     border-color: #ff0000;
     transition: 0.3s;
 }
-
+.item_box{
+    flex: 1;
+    min-width: 30%;
+    min-height: 100px;
+    border: 1px solid rgba(68, 68, 68, 0.25);
+    border-radius: 8px;
+    margin: 5px;
+    word-wrap: break-word;
+}
 .github-icon{
-    width: 25px;
+    width: 30px;
 }
 .inactive{
     filter: opacity(0.5);

--- a/resources/js/components/servicos/MyServices.vue
+++ b/resources/js/components/servicos/MyServices.vue
@@ -5,7 +5,7 @@
             <div class="w-100">
                 <div class="col-sm-12 p-3 text-start w-100">
                     <p class="title mb-1"><strong>{{service.title}}</strong></p>
-                    <p>{{service.description.substring(0,150)}} <i v-if="service.description.length > 150">...</i></p>
+                    <p>{{service.description.substring(0,150)}}<i v-if="service.description.length > 150">...</i></p>
                 </div>
 
                 <div class="p-1 w-100">

--- a/resources/js/components/servicos/MyServices.vue
+++ b/resources/js/components/servicos/MyServices.vue
@@ -1,46 +1,71 @@
 <template>
-    <div class="p-1 col-sm-12 col-md-4">
-        <div class="my-service text-center " :class="service.status|status_class">
-            <div class="col-sm-12 text-start">
-                <p><strong>{{service.title}}</strong></p>
-                <p>{{service.description.substring(0,150)+"..." }}</p>
-            </div>
+    <div class="p-1 col-sm-15 col-md-4">
+        <div class="my-service text-center" :class="service.status|status_class">
 
-            <table class="col-12 mb-2">
-                <thead>
-                <tr>
-                    <th>Id</th>
-                    <th>Categoria</th>
-                    <th>Data</th>
-                </tr>
-                </thead>
-                <tbody>
-                <tr>
-                    <td>{{service.id}}</td>
-                    <td>{{service.specification_id}}</td>
-                    <td>{{service.created_at | formatDate}}</td>
-                </tr>
-                </tbody>
-            </table>
-
-            <div class="col-12 mt-3 row">
-                <div class="col-sm-6">
-                    <span class="material-icons col-12">grading</span>
-                    <a :href="'/servico/'+service.id+'/edit'"
-                        class="p-2"
-                    >Editar</a>
+            <div class="w-100">
+                <div class="col-sm-12 p-3 text-start w-100">
+                    <p class="title mb-1"><strong>{{service.title}}</strong></p>
+                    <p>{{service.description.substring(0,150)}} <i v-if="service.description.length > 150">...</i></p>
                 </div>
-                <div class="col-sm-6">
-                    <a :href="'/servico/'+service.id">
-                        <span class="material-icons">insert_comment</span>
-                        <p>Acompanhar</p>
-                    </a>
+
+                <div class="p-1 w-100">
+                    <div class="col-12 mb-2 d-flex justify-center align-items-stretch flex-wrap">
+                        <div class="d-flex flex-column justify-content-center item_box">
+                            <div class="p-2">
+                                <b>Id</b>
+                            </div>
+                            <div class="p-2">
+                                {{service.id}}
+                            </div>
+                        </div>
+                        <div class="d-flex flex-column justify-content-center item_box">
+                            <div class="p-2">
+                                <b>Categoria</b>
+                            </div>
+                            <div class="p-2">
+                                {{service.specification_id}}
+                            </div>
+                        </div>
+                        <div class="d-flex flex-column justify-content-center item_box">
+                            <div class="p-2">
+                                <b>Data</b>
+                            </div>
+                            <div class="p-2">
+                                {{service.created_at | formatDate}}
+                            </div>
+                        </div>
+                        <div class="d-flex flex-column justify-content-center item_box" v-if="service.delivery_date">
+                            <div class="p-2">
+                                <b>Data de Entrega</b>
+                            </div>
+                            <div class="p-2">
+                                {{service.delivery_date | formatDate}}
+                            </div>
+                        </div>
+                    </div>
                 </div>
             </div>
 
-            <div class="col-12 text-end text-muted "> 
-                <small><i class="bi bi-alarm"></i> última atualização {{service.updated_at | prettyDate}}</small>
+            <div class="w-100">
+                <div class="d-flex flex-row justify-content-center w-100 p-2">
+                    <div class="col-sm-6">
+                        <a :href="'/servico/'+service.id+'/edit'">
+                        <span class="material-icons col-12">grading</span>
+                        Editar</a>
+                    </div>
+                    <div class="col-sm-6">
+                        <a :href="'/servico/'+service.id">
+                            <span class="material-icons">insert_comment</span>
+                            <p>Acompanhar</p>
+                        </a>
+                    </div>
+                </div>
+
+                <div class="col-12 text-end text-muted p-2">
+                    <small><i class="bi bi-alarm"></i> última atualização {{service.updated_at | prettyDate}}</small>
+                </div>
             </div>
+
         </div>
    </div>
 </template>
@@ -58,15 +83,16 @@ export default {
     background-color: #f0f0f0;
     border-left: 5px solid;
     border-radius: 8px;
-    padding: 30px;
+    padding: 0px, 30px;
     height: 100%;
 
     display: flex;
-    flex-direction: row;
+    flex-direction: column;
     flex-wrap: wrap;
-    justify-content: space-around;
+    justify-content: space-between;
     align-content: center;
     align-items: center;
+    word-wrap: break-word;
 }
 .my-service:hover{
     background-color: #ededed;
@@ -106,6 +132,15 @@ a, a:hover, a:visited, a:active{
 .recusado:hover{
     border-color: #ff0000;
     transition: 0.3s;
+}
+.item_box{
+    flex: 1;
+    min-width: 30%;
+    min-height: 100px;
+    border: 1px solid rgba(68, 68, 68, 0.25);
+    border-radius: 8px;
+    margin: 5px;
+    word-wrap: break-word;
 }
 
 </style>

--- a/resources/js/components/servicos/ServiceForm.vue
+++ b/resources/js/components/servicos/ServiceForm.vue
@@ -1,6 +1,6 @@
 <template>
           <form @submit.prevent="create" class="mb-3">
-            <div class="form-group my-3 is-invalid">
+            <div class="form-group my-3">
                 <label for="title">Título</label>
                 <input type="text" class="form-control"
                        id="title" placeholder="Exemplo: Audio para exercício da aula de Espanhol I"
@@ -18,7 +18,7 @@
             <div class="form-group">
                 <label for="delivery_date">Data de Entrega</label>
                 <input type="date" class="form-control"
-                       id="delivery_date" style="width:auto;" v-model="delivery_date" :min="min_date">
+                       id="delivery_date" style="width:auto;" v-model="delivery_date" :min="min_date" required>
                 <small><span class="helper-text text-muted">
                     Prazo mínimo de 10 dias.
                 </span></small>
@@ -161,9 +161,7 @@ export default {
             }
         },
         checkDeliveryDate(){
-            if(new Date(this.delivery_date) < new Date(this.min_date)){
-                console.log("é menor");
-
+            if(new Date(this.delivery_date) < new Date(this.min_date) || !this.delivery_date){
                 return false;
             }
             return true;

--- a/resources/js/components/servicos/ServiceForm.vue
+++ b/resources/js/components/servicos/ServiceForm.vue
@@ -217,6 +217,7 @@ export default {
             this.categoryId = '';
             this.locationId = '';
             this.description = '';
+            this.delivery_date = '';
         },
     },
     created() {

--- a/resources/js/pages/EditPage.vue
+++ b/resources/js/pages/EditPage.vue
@@ -2,22 +2,30 @@
     <section class="mb-3 container">
         <form @submit.prevent="create">
             <h2>Edição da solicitação #{{item.id}}</h2>
-            <div class="form-group">
+            <hr>
+            <div class="form-group m-2">
                 <label for="title">Título</label>
                 <input type="text" class="form-control"
                        id="title" placeholder="Título"
                        v-model="title" required>
-                <span class="helper-text">Ex.: Jogos digitais em aula</span>
+                <small><span class="helper-text text-muted">Ex.: Jogos digitais em aula</span></small>
             </div>
-            <div class="form-group">
+            <div class="form-group m-2">
                 <label for="description">Descrição</label>
                 <textarea type="text" class="form-control"
                        id="description" placeholder="Descrição"
                        v-model="description" required>
                 </textarea>
             </div>
-
-            <div class="form-group">
+            <div class="form-group m-2">
+                <label for="delivery_date">Data de Entrega</label>
+                <input type="date" class="form-control"
+                       id="delivery_date" style="width:auto;" v-model="delivery_date" :min="min_date" required>
+                <small><span class="helper-text text-muted">
+                    Prazo mínimo de 10 dias.
+                </span></small>
+            </div>
+            <div class="form-group m-2">
                 <label for="categoria">Tipo de Serviço</label>
                 <select id="category" class="form-control" v-model="categoryId" required
                         @change="filterSpecification">
@@ -38,11 +46,11 @@
                             :value="specification.id"
                         >{{specification.title}}</option>
                     </select>
-                    <small>em caso de dúvidas sobre os tipo de seviços do PRACTICE consulte nosso
-                        <a href="https://practice.uffs.cc/" target="_blank">site</a></small>
+                    <small><span class="helper-text text-muted">Em caso de dúvidas sobre os tipos de serviços do PRACTICE, consulte nosso <a href="https://practice.uffs.cc/" target="_blank">site</a>.</span>
+                    </small>
                 </div>
             </div>
-            <div class="form-group">
+            <div class="form-group m-2">
                 <label for="categoria">Localização</label>
                 <select id="localization" class="form-control" v-model="locationId" required>
                     <option value="" disabled selected>Selecione a Localização da Solicitação</option>
@@ -53,23 +61,23 @@
                     >{{localizacao.name}}</option>
                 </select>
             </div>
-            <div v-if="user.type=='admin' && item.type==2">
-                <hr>
-                <h4>Dados disponíveis apenas para adminstradores</h4>
-                <div class="form-group">
+
+            <div class="form-group my-2" v-if="user.type=='admin' && item.type==2">
+                <hr class="my-3">
+                <h4 class="my-2">Dados disponíveis apenas para adminstradores</h4>
+                <div class="form-group m-2">
                     <label for="github_issue_link">GitHub Issue Link</label>
                     <input type="text" class="form-control"
                         id="github_issue_link" placeholder="GitHub Issue Link"
                         v-model="github_issue_link">
                 </div>
-                <div class="form-group">
+                <div class="form-group m-2">
                     <label for="categoria">Status da Solicitação</label>
                     <select class="form-control" v-model="status" required >
                         <option value="1">No Aguardo</option>
                         <option value="2">Em Processo</option>
                         <option value="3">Concluído</option>
                         <option value="4">Recusado</option>
-
                     </select>
                 </div>
             </div>
@@ -101,6 +109,8 @@ export default {
             specificationId:this.item.specification_id,
             github_issue_link:this.item.github_issue_link,
             status:this.item.status,
+            min_date:new Date(this.item.created_at),
+            delivery_date: this.item.delivery_date,
         }
     },
     mounted(){
@@ -140,19 +150,46 @@ export default {
                 'specification_id': this.specificationId,
                 'github_issue_link':this.github_issue_link,
                 'status':this.status,
+                'delivery_date': this.delivery_date,
             };
 
-            try {
-                let response = await window.axios.put(`/api/services/${this.item.id}`, data,{
-                    headers:{
-                        'Authorization': `Bearer ${this.token.access_token}`
-                    },
-                });
-                this.handleSuccess(response);
+            if(this.checkDeliveryDate()){
+                try {
+                    let response = await window.axios.put(`/api/services/${this.item.id}`, data,{
+                        headers:{
+                            'Authorization': `Bearer ${this.token.access_token}`
+                        },
+                    });
+                    this.handleSuccess(response);
+                }
+                catch(err) {
+                    this.handleError(err);
+                }
             }
-            catch(err) {
-                this.handleError(err);
+            else{
+                const Toast = Swal.mixin({
+                    toast: true,
+                    position: 'center',
+                    showConfirmButton: false,
+                    timer: 3000,
+                    timerProgressBar: true,
+                    didOpen: (toast) => {
+                        toast.addEventListener('mouseenter', Swal.stopTimer)
+                        toast.addEventListener('mouseleave', Swal.resumeTimer)
+                    }
+                })
+
+                Toast.fire({
+                    icon: 'error',
+                title: 'Selecione uma Data de Entrega válida!!'
+                })
             }
+        },
+        checkDeliveryDate(){
+            if(new Date(this.delivery_date) < new Date(this.min_date) || !this.delivery_date){
+                return false;
+            }
+            return true;
         },
         handleError(err){
             let data = err.response.data;
@@ -192,7 +229,7 @@ export default {
                     icon: 'success',
                     title: 'Serviço Editado com sucesso!!'
                 }).then(function(){
-                    location.href = '/admin';
+                    location.href = '/servicos/acompanhar';
                 })
 
         },
@@ -201,6 +238,7 @@ export default {
             this.categoryId = '';
             this.locationId = '';
             this.description = '';
+            this.delivery_date = '';
         },
     },
     created() {
@@ -209,11 +247,17 @@ export default {
         if(this.item.type==2){
             this.getSpecification();
         }
-
+        this.min_date = new Date(this.min_date.setDate(this.min_date.getDate() + 10)).toISOString("yyyy-mm-dd").substring(0, 10);
     },
 }
 </script>
 
-<style>
-
+<style scoped>
+    h2{
+        font-weight: bold;
+        font-size: 1.2rem;
+    }
+    h4{
+        font-weight: bold;
+    }
 </style>

--- a/resources/js/pages/ItemPage.vue
+++ b/resources/js/pages/ItemPage.vue
@@ -1,11 +1,12 @@
 <template>
   <section class="col-8">
-      <h6>{{item.user}}</h6> 
-      <h4>{{item.title}}</h4> 
+      <h6>{{item.user}}</h6>
+      <h4>{{item.title}}</h4>
       <p v-if="item.github_issue_link"><a :href="item.github_issue_link" target="_blank"><small>(issue: #{{issue}}) Acompanhe essa solicitação no GitHub</small></a></p>
       <p><small>Categoria: {{item.category_id}}</small>
-         <small v-if="item.specification_id">:{{item.specification_id.title}}</small>, 
-         <small>Localização: {{item.location_id}}</small></p>
+         <small v-if="item.specification_id">- {{item.specification_id.title}}</small> <i>|</i>
+         <small>Localização: {{item.location_id}}</small> <i v-if="item.delivery_date">|</i>
+         <small v-if="item.delivery_date">Data de Entrega: {{item.delivery_date | formatDate}}</small></p>
       <p>{{item.description}}</p>
       <p class="text-end"> <small> última atualização {{item.updated_at | prettyDate}}</small></p>
     <hr>

--- a/resources/js/pages/ItemPage.vue
+++ b/resources/js/pages/ItemPage.vue
@@ -3,12 +3,14 @@
         <h6>Solicitante: {{item.user}}</h6>
         <hr>
         <h4>{{item.title}}</h4>
-        <p v-if="item.github_issue_link"><a :href="item.github_issue_link" target="_blank"><small>(issue: #{{issue}}) Acompanhe essa solicitação no GitHub</small></a></p>
-        <small>Categoria: {{item.category_id}}</small>
-        <small v-if="item.specification_id">- {{item.specification_id.title}}</small>
-        <small> | Localização: {{item.location_id}}</small>
-        <small v-if="item.delivery_date"> | Data de Entrega: {{item.delivery_date | formatDate}}</small>
-        <p class="my-2">{{item.description}}</p>
+        <p class="title_foot" v-if="item.github_issue_link"><a :href="item.github_issue_link" target="_blank"><small>(issue: #{{issue}}) Acompanhe essa solicitação no GitHub</small></a></p>
+        <p class="title_foot">
+            <small>Categoria: {{item.category_id}}</small>
+            <small v-if="item.specification_id">- {{item.specification_id.title}}</small>
+            <small> | Localização: {{item.location_id}}</small>
+            <small v-if="item.delivery_date"> | Data de Entrega: {{item.delivery_date | formatDate}}</small>
+        </p>
+        <p class="my-2 border p-2 rounded">{{item.description}}</p>
         <p class="text-end"> <small> última atualização {{item.updated_at | prettyDate}}</small></p>
         <hr>
         <comment-list :user="user" :item-id="item.id" :token="token" class="my-1"></comment-list>
@@ -36,5 +38,8 @@ export default {
         font-size: 1.2rem;
         font-weight: bold;
         margin-top: 10px;
+    }
+    .title_foot{
+        line-height: 1.1;
     }
 </style>

--- a/resources/js/pages/ItemPage.vue
+++ b/resources/js/pages/ItemPage.vue
@@ -1,17 +1,18 @@
 <template>
-  <section class="col-8">
-      <h6>{{item.user}}</h6>
-      <h4>{{item.title}}</h4>
-      <p v-if="item.github_issue_link"><a :href="item.github_issue_link" target="_blank"><small>(issue: #{{issue}}) Acompanhe essa solicitação no GitHub</small></a></p>
-      <p><small>Categoria: {{item.category_id}}</small>
-         <small v-if="item.specification_id">- {{item.specification_id.title}}</small> <i>|</i>
-         <small>Localização: {{item.location_id}}</small> <i v-if="item.delivery_date">|</i>
-         <small v-if="item.delivery_date">Data de Entrega: {{item.delivery_date | formatDate}}</small></p>
-      <p>{{item.description}}</p>
-      <p class="text-end"> <small> última atualização {{item.updated_at | prettyDate}}</small></p>
-    <hr>
-    <comment-list :user="user" :item-id="item.id" :token="token"></comment-list>
-  </section>
+    <section class="col-8">
+        <h6>Solicitante: {{item.user}}</h6>
+        <hr>
+        <h4>{{item.title}}</h4>
+        <p v-if="item.github_issue_link"><a :href="item.github_issue_link" target="_blank"><small>(issue: #{{issue}}) Acompanhe essa solicitação no GitHub</small></a></p>
+        <small>Categoria: {{item.category_id}}</small>
+        <small v-if="item.specification_id">- {{item.specification_id.title}}</small> <i>|</i>
+        <small>Localização: {{item.location_id}}</small> <i v-if="item.delivery_date">|</i>
+        <small v-if="item.delivery_date">Data de Entrega: {{item.delivery_date | formatDate}}</small>
+        <p class="my-2">{{item.description}}</p>
+        <p class="text-end"> <small> última atualização {{item.updated_at | prettyDate}}</small></p>
+        <hr>
+        <comment-list :user="user" :item-id="item.id" :token="token" class="my-1"></comment-list>
+    </section>
 </template>
 
 <script>
@@ -31,5 +32,9 @@ export default {
 </script>
 
 <style scoped>
-
+    h4{
+        font-size: 1.2rem;
+        font-weight: bold;
+        margin-top: 10px;
+    }
 </style>

--- a/resources/js/pages/ItemPage.vue
+++ b/resources/js/pages/ItemPage.vue
@@ -5,9 +5,9 @@
         <h4>{{item.title}}</h4>
         <p v-if="item.github_issue_link"><a :href="item.github_issue_link" target="_blank"><small>(issue: #{{issue}}) Acompanhe essa solicitação no GitHub</small></a></p>
         <small>Categoria: {{item.category_id}}</small>
-        <small v-if="item.specification_id">- {{item.specification_id.title}}</small> <i>|</i>
-        <small>Localização: {{item.location_id}}</small> <i v-if="item.delivery_date">|</i>
-        <small v-if="item.delivery_date">Data de Entrega: {{item.delivery_date | formatDate}}</small>
+        <small v-if="item.specification_id">- {{item.specification_id.title}}</small>
+        <small> | Localização: {{item.location_id}}</small>
+        <small v-if="item.delivery_date"> | Data de Entrega: {{item.delivery_date | formatDate}}</small>
         <p class="my-2">{{item.description}}</p>
         <p class="text-end"> <small> última atualização {{item.updated_at | prettyDate}}</small></p>
         <hr>


### PR DESCRIPTION
fix: #305 

Foi adicionado o **delivery_date** nos formulários de solicitação, de edição. Algumas coisas visuais foram alteradas para conseguir adicionar a data de entrega:

- As caixas de serviço da aba de "Acompanhar Serviços"
![image](https://user-images.githubusercontent.com/51202705/121188474-86809280-c83f-11eb-90e5-8c05d445da9a.png)

- As caixas de serviço da aba de "Admin"
![image](https://user-images.githubusercontent.com/51202705/121188717-c0ea2f80-c83f-11eb-8a27-1fc823e4c107.png)

- A página de edição de serviços
![image](https://user-images.githubusercontent.com/51202705/121188852-e414df00-c83f-11eb-8eb9-07485f6c0943.png)

- Página de acompanhamento de serviço
![image](https://user-images.githubusercontent.com/51202705/121188957-fd1d9000-c83f-11eb-9f43-3e75e226232b.png)

A data de entrega foi limitada atravéz do min dentro do input date e também foi feito uma validação dentro do próprio formulário caso o "min" seja removido via ferramentas de desenvolvedor.

![image](https://user-images.githubusercontent.com/51202705/121189548-95b41000-c840-11eb-8227-b82a1c6b4441.png)

A mesma coisa foi feita na aba de edição, porém, utilizando a data de criação como referência dos 10 dias, e não o dia atual.

**obs:** Também tive que atualizar a migration do item, para adicionar o delivery_date



