### PR TITLE
fix: responsividade das perguntas adicionais

### DIFF
--- a/resources/views/livewire/order/show.blade.php
+++ b/resources/views/livewire/order/show.blade.php
@@ -10,9 +10,9 @@
                     {{ $order->description }}
                 </p>
                 @if ($order->data)
-                    <div class="text-sm py-4">
+                    <div class="text-sm py-4 w-100">
                         <p class="font-medium py-2">Informações adicionais</p>
-                        <table>
+                        <table class="w-100">
                             <thead class="d-xl-block d-none">
                                 <tr class="row t-row mw-100">
                                     <th class="col-xl-5">Pergunta</th>


### PR DESCRIPTION
Modifiquei o formato da exibição das perguntas e respostas adicionais de um pedido. Para telas maiores que 1200px mantive como estava antes:

![image](https://user-images.githubusercontent.com/51202548/169826973-3353b6fe-a094-419f-87d4-d395b3dda6bf.png)

Para telas menores que 1200px coloquei a resposta abaixo da pergunta para facilitar a leitura:

![image](https://user-images.githubusercontent.com/51202548/169826914-866a4334-3bf0-49f4-8a28-693cd1f2c326.png)

Fix: #478